### PR TITLE
fix(pom): fix resources path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,17 +182,6 @@
 	</dependencyManagement>
 
 	<build>
-		<resources>
-			<resource>
-				<directory>src/main/java</directory><!--所在的目录-->
-				<includes><!--包括目录下的.properties,.xml文件都会扫描到-->
-					<include>**/*.properties</include>
-					<include>**/*.xml</include>
-					<include>**/*.xml</include>
-				</includes>
-				<filtering>false</filtering>
-			</resource>
-		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Spring Boot 默认可以识别 `/src/main/resources/application.yml` 配置文件，不需要在 pom.xml 里配置 `<resources>` 标签。

@xuenanhkust 